### PR TITLE
Update background color to #2a475c for location-details page

### DIFF
--- a/src/components/LocationDetail.js
+++ b/src/components/LocationDetail.js
@@ -22,7 +22,7 @@ import { CampyContext } from "../CampyContext";
 
 const useStyles = makeStyles((theme) => ({
   background: {
-    background: "#22577A",
+    background: "#2a475c",
     height: "100vh",
     width: "100%",
     marginTop: "75px",
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
       margin: "10px",
       color: "white",
     },
-    background: "#22577A",
+    background: "#2a475c",
     display: "flex",
     alignItems: "flex-start",
     justifyContent: "space-evenly",

--- a/src/components/protectedRoutes/AddLocation.js
+++ b/src/components/protectedRoutes/AddLocation.js
@@ -38,7 +38,7 @@ const checkBoxStyles = (theme) => ({
 
 const CustomCheckbox = withStyles(checkBoxStyles)(Checkbox);
 export const AddLocation = () => {
-  
+
   const history = useHistory();
   const classes = useStyles();
   const { currentUser, authAxios } = useContext(CampyContext);
@@ -50,7 +50,7 @@ export const AddLocation = () => {
   const [website, setWebsite] = useState("");
   const [description, setDescription] = useState("");
   const [host_notes, setHost_Notes] = useState("");
-  
+
   const [electric_hookup, setElectric_Hookup] = useState(false);
   const [water_hookup, setWater_Hookup] = useState(false);
   const [septic_hookup, setSeptic_Hookup] = useState(false);
@@ -112,7 +112,7 @@ export const AddLocation = () => {
 
       .catch((err) => console.log(err));
   };
-  
+
   return currentUser ? (
     <Grid
       container


### PR DESCRIPTION
![Location-Details](https://user-images.githubusercontent.com/56603706/93717521-54f65880-fb44-11ea-9021-419caf7acfdc.JPG)

I changed the background color to a darker color, I felt a light on light color with the background for each item on the location-details page would look homely.

I don't really want to deviate away from blue, since I honestly don't care about the color scheme that much. I just don't want to find and debate a new color scheme. I felt the background color was too close to the header, so somewhere in between the color hue of the header and the footer would kind of bring a good flow together.